### PR TITLE
Efficient dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/crd-schema-gen

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ COPY . .
 ENV GO_PACKAGE github.com/openshift/crd-schema-gen
 RUN go build -o crd-schema-gen cmd/crd-schema-gen/main.go
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/crd-schema-gen/crd-schema-gen /
-COPY --from=builder /usr /usr
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
+COPY --from=builder /go/src/github.com/openshift/crd-schema-gen/crd-schema-gen /usr/local/bin
 ENV GOPATH=/go
-ENV PATH="/usr/local/go/bin:${PATH}"
-ENTRYPOINT ["/crd-schema-gen"]
+ENTRYPOINT ["/usr/local/bin/crd-schema-gen"]


### PR DESCRIPTION
* Remove binary from git sources
* Copy just the binary to resulting container

TODO:
* [x] Use golang image as a base:
```
Copying "pkg/apis//"* to temporary "/go/531315973/pkg/apis"...
'go list' driver requires 'go', but executable file not found in $PATH
```